### PR TITLE
Enable IPv6 by default

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1165,7 +1165,8 @@ void ContextImpl::tickSearch(SearchKind kind, bool poked)
                 if(err==EINTR || err==EPERM)
                     lvl = Level::Debug;
                 log_printf(io, lvl, "Search tx %s error (%d) %s\n",
-                           pair.first.addr.tostring().c_str(), err, evutil_socket_error_to_string(err));
+                           std::string(SB()<<pair.first).c_str(),
+                           err, evutil_socket_error_to_string(err));
 
             } else if(unsigned(ntx)<consumed) {
                 log_warn_printf(io, "Search truncated %u < %u",

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -287,6 +287,8 @@ void expandAddrList(const std::vector<SockEndpoint>& ifaces,
     SockAttach attach;
     evsocket dummy(AF_INET, SOCK_DGRAM, 0);
 
+    auto& ifmap = IfaceMap::instance();
+
     for(auto& saddr : ifaces) {
         auto matchAddr = &saddr.addr;
 
@@ -295,13 +297,32 @@ void expandAddrList(const std::vector<SockEndpoint>& ifaces,
             // treat [::] as 0.0.0.0
             matchAddr = nullptr;
 
-        } else if(saddr.addr.family()!=AF_INET) {
-            continue;
         }
 
-        for(auto& addr : dummy.broadcasts(matchAddr)) {
-            addr.setPort(0u);
-            addrs.emplace_back(addr);
+        // add ipv6 before ipv4.  order is preserved, so ipv6 searches go out first.
+        if(saddr.addr.family()==AF_INET6 || (evsocket::ipstack==evsocket::Linsock && saddr.addr.isAny())) {
+            const SockAddr mcast("[ff02::70:7661]");
+
+            if(saddr.addr.isAny()) {
+                epicsGuard<epicsMutex> G(ifmap.lock);
+                for(const auto& ifpair : ifmap.byIndex) {
+                    if(ifpair.second.isLO)
+                        continue; // ipv6 doesn't seem to support mcast via. loopback :(
+                    addrs.emplace_back(mcast);
+                    addrs.back().ttl = 1;
+                    addrs.back().iface = ifpair.second.name;
+                }
+            } else {
+                addrs.emplace_back(mcast);
+                addrs.back().ttl = 1;
+                addrs.back().iface = ifmap.name_of(saddr.addr);
+            }
+        }
+        if(saddr.addr.family()==AF_INET || matchAddr==nullptr) {
+            for(auto& addr : dummy.broadcasts(matchAddr)) {
+                addr.setPort(0u);
+                addrs.emplace_back(addr);
+            }
         }
     }
 }

--- a/src/os/default/osdSockExt.cpp
+++ b/src/os/default/osdSockExt.cpp
@@ -241,6 +241,15 @@ decltype (IfaceMap::byIndex) IfaceMap::_refresh() {
                 it = pair.first;
             }
 
+            if(af==AF_INET6) {
+                auto addr6 = (sockaddr_in6*)&ifa->ifa_addr;
+                // link local must have scope (aka. interface index) to disambiguate.
+                // others ipv6 addresses assumed to be unambiguous.
+                if(IN6_IS_ADDR_LINKLOCAL(&addr6->sin6_addr) && addr6->sin6_scope_id==0) {
+                    addr6->sin6_scope_id = idx;
+                }
+            }
+
             // IFF_BROADCAST does not apply to IPv6
             bool hasB = af==AF_INET && (ifa->ifa_flags&IFF_BROADCAST) && ifa->ifa_broadaddr;
 


### PR DESCRIPTION
Something I have been testing locally for the past few months.  When/if we have an IPv6 [link-local](https://www.iana.org/assignments/ipv6-multicast-addresses/ipv6-multicast-addresses.xhtml#link-local) address [assigned](https://www.iana.org/form/multicast-ipv6) (or just arbitrarily selected), it is straightforward to begin using in much the same way as an IPv4 broadcast address.

In this case I use `[ff02::70:7661]` as a placeholder.  The last 3 bytes will also appear in the ethernet destination address, and picking something otherwise unused facilitates hardware filtering.

I don't have a definite timeline for moving forward with this idea.

@kasemir fyi.